### PR TITLE
Implement metrics for the Upper MAC

### DIFF
--- a/include/l2/logical_channel.hpp
+++ b/include/l2/logical_channel.hpp
@@ -11,23 +11,23 @@
 #include "utils/bit_vector.hpp"
 
 enum class LogicalChannel {
-    kSignalingChannelHalfDownlink,
-    kSignalingChannelHalfUplink,
+    kSignallingChannelHalfDownlink,
+    kSignallingChannelHalfUplink,
     kTrafficChannel,
-    kSignalingChannelFull,
+    kSignallingChannelFull,
     kStealingChannel
 };
 
 constexpr auto to_string(LogicalChannel channel) noexcept -> const char* {
     switch (channel) {
-    case LogicalChannel::kSignalingChannelHalfDownlink:
-        return "SignalingChannelHalfDownlink";
-    case LogicalChannel::kSignalingChannelHalfUplink:
-        return "SignalingChannelHalfUplink";
+    case LogicalChannel::kSignallingChannelHalfDownlink:
+        return "SignallingChannelHalfDownlink";
+    case LogicalChannel::kSignallingChannelHalfUplink:
+        return "SignallingChannelHalfUplink";
     case LogicalChannel::kTrafficChannel:
         return "TrafficChannel";
-    case LogicalChannel::kSignalingChannelFull:
-        return "SignalingChannelFull";
+    case LogicalChannel::kSignallingChannelFull:
+        return "SignallingChannelFull";
     case LogicalChannel::kStealingChannel:
         return "StealingChannel";
     }
@@ -38,6 +38,6 @@ struct LogicalChannelDataAndCrc {
     LogicalChannel channel;
     /// the data on the logical channel
     BitVector data;
-    /// true if the crc of the signaling channels is ok
+    /// true if the crc of the signalling channels is ok
     bool crc_ok;
 };

--- a/include/l2/lower_mac.hpp
+++ b/include/l2/lower_mac.hpp
@@ -72,7 +72,8 @@ class LowerMacPrometheusCounters {
     prometheus::Gauge& lower_mac_prediction_time_;
 
   public:
-    LowerMacPrometheusCounters(std::shared_ptr<PrometheusExporter>& prometheus_exporter)
+    LowerMacPrometheusCounters() = delete;
+    explicit LowerMacPrometheusCounters(std::shared_ptr<PrometheusExporter>& prometheus_exporter)
         : burst_received_count_family_(prometheus_exporter->burst_received_count())
         , control_uplink_burst_received_count_(burst_received_count_family_.Add({{"burst_type", "ControlUplinkBurst"}}))
         , normal_uplink_burst_received_count_(burst_received_count_family_.Add({{"burst_type", "NormalUplinkBurst"}}))

--- a/include/l2/slot.hpp
+++ b/include/l2/slot.hpp
@@ -111,99 +111,10 @@ class Slots {
     Slots(const Slots&) = default;
 
     /// constructor for one subslot or a full slot
-    Slots(BurstType burst_type, SlotsType slot_type, Slot&& slot)
-        : burst_type_(burst_type)
-        , slot_type_(slot_type)
-        , slots_({std::move(slot)}) {
-        if (slot_type_ == SlotsType::kTwoSubslots) {
-            throw std::runtime_error("Two subslots need to to have two subslots");
-        }
-
-        /// If we processes the normal uplink burst assume that the slot is signalling and not traffic. We would need
-        /// the information from the access assignment from the corresponding downlink timeslot to make the right
-        /// decision here.
-        if (burst_type_ == BurstType::NormalUplinkBurst) {
-            get_first_slot().select_logical_channel(LogicalChannel::kSignalingChannelFull);
-        }
-
-        if (!get_first_slot().is_concreate()) {
-            throw std::runtime_error("The first or only slot is not concreate.");
-        }
-    };
+    Slots(BurstType burst_type, SlotsType slot_type, Slot&& slot);
 
     /// construct for two half slot
-    Slots(BurstType burst_type, SlotsType slot_type, Slot&& first_slot, Slot&& second_slot)
-        : burst_type_(burst_type)
-        , slot_type_(slot_type)
-        , slots_({std::move(first_slot), std::move(second_slot)}) {
-        if (slot_type_ != SlotsType::kTwoSubslots) {
-            throw std::runtime_error("Only two subslots is allowed to have two subslots");
-        }
-
-        if (!get_first_slot().is_concreate()) {
-            throw std::runtime_error("The first subslot is not concreate.");
-        }
-
-        const auto& first_slot_data = get_first_slot().get_logical_channel_data_and_crc().data;
-        if (get_first_slot().get_logical_channel_data_and_crc().channel == LogicalChannel::kStealingChannel) {
-            // The first subslot is stolen, now we need to decide if the second is also stolen or traffic
-            auto second_half_slot_stolen = false;
-
-            if (burst_type_ == BurstType::NormalUplinkBurstSplit) {
-                auto pdu_type = first_slot_data.look<2>(0);
-                // read the stolen flag from the MAC-DATA
-                // 21.4.2.3 MAC-DATA
-                if (pdu_type == 0b00) {
-                    auto address_type = first_slot_data.look<2>(4);
-                    auto length_indication_or_capacity_request_offset = 6 + (address_type == 0b01 ? 10 : 24);
-                    auto length_indication_or_capacity_request =
-                        first_slot_data.look<1>(length_indication_or_capacity_request_offset);
-                    if (length_indication_or_capacity_request == 0b0) {
-                        auto length_indication =
-                            first_slot_data.look<6>(length_indication_or_capacity_request_offset + 1);
-                        if (length_indication == 0b111110 || length_indication == 0b111111) {
-                            second_half_slot_stolen = true;
-                        }
-                    }
-                }
-
-                // read the stolen flag from the MAC-U-SIGNAL PDU
-                // 21.4.5 TMD-SAP: MAC PDU structure for U-plane signalling
-                if (pdu_type == 0b11) {
-                    if (first_slot_data.look<1>(2)) {
-                        second_half_slot_stolen = true;
-                    };
-                }
-            }
-
-            if (burst_type_ == BurstType::NormalDownlinkBurstSplit) {
-                auto pdu_type = first_slot_data.look<2>(0);
-                // read the sloten flag from the MAC-RESOURCE PDU
-                // 21.4.3.1 MAC-RESOURCE
-                if (pdu_type == 0b00) {
-                    auto length_indication = first_slot_data.look<6>(7);
-                    if (length_indication == 0b111110 || length_indication == 0b111111) {
-                        second_half_slot_stolen = true;
-                    }
-                }
-
-                // read the stolen flag from the MAC-U-SIGNAL PDU
-                // 21.4.5 TMD-SAP: MAC PDU structure for U-plane signalling
-                if (pdu_type == 0b11) {
-                    if (first_slot_data.look<1>(2)) {
-                        second_half_slot_stolen = true;
-                    };
-                }
-            }
-
-            get_second_slot().select_logical_channel(second_half_slot_stolen ? LogicalChannel::kStealingChannel
-                                                                             : LogicalChannel::kTrafficChannel);
-        }
-
-        if (!get_second_slot().is_concreate()) {
-            throw std::runtime_error("The second slot is not concreate.");
-        }
-    };
+    Slots(BurstType burst_type, SlotsType slot_type, Slot&& first_slot, Slot&& second_slot);
 
     /// access the first slot
     [[nodiscard]] auto get_first_slot() noexcept -> Slot& { return slots_.front(); };
@@ -220,23 +131,7 @@ class Slots {
     [[nodiscard]] auto has_second_slot() const noexcept -> bool { return slots_.size() == 2; }
 
     // check if there was any crc mismatch on the signalling or stealing channels
-    [[nodiscard]] auto has_crc_error() -> bool {
-        auto error = false;
-
-        const auto& first_slot = slots_.front().get_logical_channel_data_and_crc();
-        if (first_slot.channel != LogicalChannel::kTrafficChannel) {
-            error |= !first_slot.crc_ok;
-        }
-
-        if (has_second_slot()) {
-            const auto& second_slot = slots_.at(1).get_logical_channel_data_and_crc();
-            if (second_slot.channel != LogicalChannel::kTrafficChannel) {
-                error |= !first_slot.crc_ok;
-            }
-        }
-
-        return error;
-    };
+    [[nodiscard]] auto has_crc_error() -> bool;
 
     /// get the type of the underlying burst
     [[nodiscard]] auto get_burst_type() const noexcept -> BurstType { return burst_type_; }

--- a/include/l2/upper_mac.hpp
+++ b/include/l2/upper_mac.hpp
@@ -184,15 +184,14 @@ class UpperMac {
             // increment the total count and crc error count metrics
             metrics_->increment(slot);
 
-            bool decode_error = false;
-
             try {
                 packets = UpperMacPacketBuilder::parse_slot(slot);
                 // if (packets.has_user_or_control_plane_data()) {
                 //     std::cout << packets << std::endl;
                 // }
             } catch (std::runtime_error& e) {
-                decode_error = true;
+                metrics_->increment_decode_error(slot);
+
                 std::cout << "Error decoding packets: " << e.what() << std::endl;
                 return;
             }
@@ -200,13 +199,9 @@ class UpperMac {
             try {
                 processPackets(std::move(packets));
             } catch (std::runtime_error& e) {
-                decode_error = true;
-                std::cout << "Error decoding in upper mac: " << e.what() << std::endl;
-            }
-
-            // If we had an error during decoding increment the metrics
-            if (decode_error) {
                 metrics_->increment_decode_error(slot);
+
+                std::cout << "Error decoding in upper mac: " << e.what() << std::endl;
             }
         }
     }

--- a/include/l2/upper_mac.hpp
+++ b/include/l2/upper_mac.hpp
@@ -9,24 +9,179 @@
 
 #pragma once
 
+#include "l2/logical_channel.hpp"
+#include "l2/logical_link_control.hpp"
 #include "l2/upper_mac_fragments.hpp"
 #include "l2/upper_mac_packet_builder.hpp"
-#include <l2/logical_link_control.hpp>
-#include <l3/mobile_link_entity.hpp>
-#include <reporter.hpp>
+#include "l3/mobile_link_entity.hpp"
+#include "prometheus.h"
+#include "reporter.hpp"
+
+/// The class to provide prometheus metrics to the upper mac.
+/// 1. Received Slot are counted. Details about the number of Slot with CRC errors and decoding errors are saved.
+/// 2. The type of upper mac packets are counted i.e., c-plane signalling, u-plane signalling, u-plane traffic and
+/// broadcast
+/// 3. The count and type of c-plane signalling packets, divided into non fragmented and fragmented pieces
+class UpperMacPrometheusCounters {
+  private:
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    /// The family of counters for received slot
+    prometheus::Family<prometheus::Counter>& slot_received_count_family_;
+    /// The counter for received SignallingChannelHalfDownlink
+    prometheus::Counter& signalling_channel_half_downlink_received_count_;
+    /// The counter for received SignallingChannelHalfUplink
+    prometheus::Counter& signalling_channel_half_uplink_received_count_;
+    /// The counter for received TrafficChannel
+    prometheus::Counter& traffic_channel_received_count_;
+    /// The counter for received SignallingChannelFull
+    prometheus::Counter& signalling_channel_full_received_count_;
+    /// The counter for received StealingChannel
+    prometheus::Counter& stealing_channel_received_count_;
+
+    /// The family of counters for received slot with errors
+    prometheus::Family<prometheus::Counter>& slot_error_count_family_;
+
+    /// The counter for received SignallingChannelHalfDownlink with CRC errors
+    prometheus::Counter& signalling_channel_half_downlink_received_count_crc_error_;
+    /// The counter for received SignallingChannelHalfUplink with CRC errors
+    prometheus::Counter& signalling_channel_half_uplink_received_count_crc_error_;
+    /// The counter for received SignallingChannelFull with CRC errors
+    prometheus::Counter& signalling_channel_full_received_count_crc_error_;
+    /// The counter for received StealingChannel with CRC errors
+    prometheus::Counter& stealing_channel_received_count_crc_error_;
+
+    /// The counter for received SignallingChannelHalfDownlink with decoding errors
+    prometheus::Counter& signalling_channel_half_downlink_received_count_decoding_error_;
+    /// The counter for received SignallingChannelHalfUplink with decoding errors
+    prometheus::Counter& signalling_channel_half_uplink_received_count_decoding_error_;
+    /// The counter for received SignallingChannelFull with decoding errors
+    prometheus::Counter& signalling_channel_full_received_count_decoding_error_;
+    /// The counter for received StealingChannel with decoding errors
+    prometheus::Counter& stealing_channel_received_count_decoding_error_;
+
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+  public:
+    UpperMacPrometheusCounters() = delete;
+    explicit UpperMacPrometheusCounters(std::shared_ptr<PrometheusExporter>& prometheus_exporter)
+        : slot_received_count_family_(prometheus_exporter->upper_mac_total_slot_count())
+        , signalling_channel_half_downlink_received_count_(
+              slot_received_count_family_.Add({{"logical_channel", "SignallingChannelHalfDownlink"}}))
+        , signalling_channel_half_uplink_received_count_(
+              slot_received_count_family_.Add({{"logical_channel", "SignallingChannelHalfUplink"}}))
+        , traffic_channel_received_count_(slot_received_count_family_.Add({{"logical_channel", "TrafficChannel"}}))
+        , signalling_channel_full_received_count_(
+              slot_received_count_family_.Add({{"logical_channel", "SignallingChannelFull"}}))
+        , stealing_channel_received_count_(slot_received_count_family_.Add({{"logical_channel", "StealingChannel"}}))
+        , slot_error_count_family_(prometheus_exporter->upper_mac_slot_error_count())
+        , signalling_channel_half_downlink_received_count_crc_error_(slot_error_count_family_.Add(
+              {{"logical_channel", "SignallingChannelHalfDownlink"}, {"error_type", "CRC Error"}}))
+        , signalling_channel_half_uplink_received_count_crc_error_(slot_error_count_family_.Add(
+              {{"logical_channel", "SignallingChannelHalfUplink"}, {"error_type", "CRC Error"}}))
+        , signalling_channel_full_received_count_crc_error_(
+              slot_error_count_family_.Add({{"logical_channel", "SignallingChannelFull"}, {"error_type", "CRC Error"}}))
+        , stealing_channel_received_count_crc_error_(
+              slot_error_count_family_.Add({{"logical_channel", "StealingChannel"}, {"error_type", "CRC Error"}}))
+        , signalling_channel_half_downlink_received_count_decoding_error_(slot_error_count_family_.Add(
+              {{"logical_channel", "SignallingChannelHalfDownlink"}, {"error_type", "Decode Error"}}))
+        , signalling_channel_half_uplink_received_count_decoding_error_(slot_error_count_family_.Add(
+              {{"logical_channel", "SignallingChannelHalfUplink"}, {"error_type", "Decode Error"}}))
+        , signalling_channel_full_received_count_decoding_error_(slot_error_count_family_.Add(
+              {{"logical_channel", "SignallingChannelFull"}, {"error_type", "Decode Error"}}))
+        , stealing_channel_received_count_decoding_error_(
+              slot_error_count_family_.Add({{"logical_channel", "StealingChannel"}, {"error_type", "Decode Error"}})){};
+
+    /// This function is called for every slot once it is passed up from the lower MAC
+    /// \param logical_channel_data_and_crc the content of the slot
+    auto increment(const LogicalChannelDataAndCrc& logical_channel_data_and_crc) -> void {
+        switch (logical_channel_data_and_crc.channel) {
+        case LogicalChannel::kSignallingChannelHalfDownlink:
+            signalling_channel_half_downlink_received_count_.Increment();
+            break;
+        case LogicalChannel::kSignallingChannelHalfUplink:
+            signalling_channel_half_uplink_received_count_.Increment();
+            break;
+        case LogicalChannel::kTrafficChannel:
+            traffic_channel_received_count_.Increment();
+            break;
+        case LogicalChannel::kSignallingChannelFull:
+            signalling_channel_full_received_count_.Increment();
+            break;
+        case LogicalChannel::kStealingChannel:
+            stealing_channel_received_count_.Increment();
+            break;
+        }
+
+        if (!logical_channel_data_and_crc.crc_ok) {
+            switch (logical_channel_data_and_crc.channel) {
+            case LogicalChannel::kSignallingChannelHalfDownlink:
+                signalling_channel_half_downlink_received_count_crc_error_.Increment();
+                break;
+            case LogicalChannel::kSignallingChannelHalfUplink:
+                signalling_channel_half_uplink_received_count_crc_error_.Increment();
+                break;
+            case LogicalChannel::kTrafficChannel:
+                break;
+            case LogicalChannel::kSignallingChannelFull:
+                signalling_channel_full_received_count_crc_error_.Increment();
+                break;
+            case LogicalChannel::kStealingChannel:
+                stealing_channel_received_count_crc_error_.Increment();
+                break;
+            }
+        }
+    }
+};
 
 class UpperMac {
   public:
     UpperMac() = delete;
-    UpperMac(std::shared_ptr<Reporter> reporter, bool is_downlink)
+    UpperMac(std::shared_ptr<PrometheusExporter>& prometheus_exporter, std::shared_ptr<Reporter> reporter,
+             bool is_downlink)
         : reporter_(std::move(reporter))
         , mobile_link_entity_(std::make_shared<MobileLinkEntity>(reporter_, is_downlink))
-        , logical_link_control_(std::make_unique<LogicalLinkControl>(reporter_, mobile_link_entity_)){};
+        , logical_link_control_(std::make_unique<LogicalLinkControl>(reporter_, mobile_link_entity_)) {
+        if (prometheus_exporter) {
+            metrics_ = std::make_unique<UpperMacPrometheusCounters>(prometheus_exporter);
+        }
+    };
     ~UpperMac() noexcept = default;
+
+    /// process the slots from the lower MAC
+    /// \param slots the slots from the lower MAC
+    auto process(Slots& slots) -> void {
+        UpperMacPackets packets;
+
+        // std::cout << slots;
+
+        // increment the total count and crc error count metrics
+        metrics_->increment(slots.get_first_slot().get_logical_channel_data_and_crc());
+        if (slots.has_second_slot()) {
+            metrics_->increment(slots.get_second_slot().get_logical_channel_data_and_crc());
+        }
+
+        try {
+            packets = UpperMacPacketBuilder::parse_slots(slots);
+            // if (packets.has_user_or_control_plane_data()) {
+            //     std::cout << packets << std::endl;
+            // }
+        } catch (std::runtime_error& e) {
+            std::cout << "Error decoding packets: " << e.what() << std::endl;
+            return;
+        }
+
+        try {
+            processPackets(std::move(packets));
+
+        } catch (std::runtime_error& e) {
+            std::cout << "Error decoding in upper mac: " << e.what() << std::endl;
+        }
+    }
 
     /// process Upper MAC packets and perform fragment reconstruction and pass it to the upper layers
     /// \param packets the packets that were parsed in the upper MAC layer
-    auto process(UpperMacPackets&& packets) -> void {
+    auto processPackets(UpperMacPackets&& packets) -> void {
         for (const auto& packet : packets.c_plane_signalling_packets_) {
             // TODO: handle fragmentation over STCH
             if (packet.is_downlink_fragment() || packet.is_uplink_fragment()) {
@@ -46,6 +201,8 @@ class UpperMac {
     std::shared_ptr<Reporter> reporter_;
     std::shared_ptr<MobileLinkEntity> mobile_link_entity_;
     std::unique_ptr<LogicalLinkControl> logical_link_control_;
+
+    std::unique_ptr<UpperMacPrometheusCounters> metrics_;
 
     UpperMacFragmentation fragmentation_;
 };

--- a/include/l2/upper_mac_packet_builder.hpp
+++ b/include/l2/upper_mac_packet_builder.hpp
@@ -89,14 +89,6 @@ class UpperMacPacketBuilder {
                                              unsigned _BitInt(1) fill_bit_indication,
                                              std::optional<std::size_t> length = std::nullopt) -> BitVector;
 
-    /// Parse a slot (singular) and extract all the contained packets
-    /// \param burst_type which burst was used to send this slot
-    /// \param logical_channel_data_and_crc the data passed from the lower mac for this slot
-    /// \return the extracted packets
-    [[nodiscard]] static auto parse_slot(BurstType burst_type,
-                                         const LogicalChannelDataAndCrc& logical_channel_data_and_crc)
-        -> UpperMacPackets;
-
     /// Parse the broadcast packet contained in a BitVector
     /// \param channel the logical channel on which the broadcast packet is sent
     /// \param data the BitVector which holds the MAC broadcast packet
@@ -136,9 +128,9 @@ class UpperMacPacketBuilder {
   public:
     UpperMacPacketBuilder() = default;
 
-    /// TODO: make this function take a const Slots reference.
-    /// Parse the slots from the lower mac and extract all the contained packets
-    /// \param slots the datastructure that contains all the information from the lower mact
+    /// Parse a slot (singular) and extract all the contained packets
+    /// \param burst_type which burst was used to send this slot
+    /// \param slot the data passed from the lower mac for this slot
     /// \return the extracted packets
-    static auto parse_slots(Slots& slots) -> UpperMacPackets;
+    [[nodiscard]] static auto parse_slot(const ConcreateSlot& slot) -> UpperMacPackets;
 };

--- a/include/prometheus.h
+++ b/include/prometheus.h
@@ -23,6 +23,8 @@ class PrometheusExporter {
     auto burst_lower_mac_decode_error_count() noexcept -> prometheus::Family<prometheus::Counter>&;
     /// The family of counters for mismatched number of bursts in the downlink lower MAC
     auto burst_lower_mac_mismatch_count() noexcept -> prometheus::Family<prometheus::Counter>&;
+    /// The family of gauges for the network time
+    auto lower_mac_time_gauge() noexcept -> prometheus::Family<prometheus::Gauge>&;
 };
 
 #endif // PROMETHEUS_H

--- a/include/prometheus.h
+++ b/include/prometheus.h
@@ -25,6 +25,11 @@ class PrometheusExporter {
     auto burst_lower_mac_mismatch_count() noexcept -> prometheus::Family<prometheus::Counter>&;
     /// The family of gauges for the network time
     auto lower_mac_time_gauge() noexcept -> prometheus::Family<prometheus::Gauge>&;
+
+    /// The family of counters for all received slots
+    auto upper_mac_total_slot_count() noexcept -> prometheus::Family<prometheus::Counter>&;
+    /// The family of counters for all received slots with errors
+    auto upper_mac_slot_error_count() noexcept -> prometheus::Family<prometheus::Counter>&;
 };
 
 #endif // PROMETHEUS_H

--- a/src/l2/lower_mac.cpp
+++ b/src/l2/lower_mac.cpp
@@ -291,6 +291,9 @@ auto LowerMac::process(const std::vector<uint8_t>& frame, BurstType burst_type) 
     // We do not have any time handling for uplink processing.
     if (sync_ && is_downlink_burst(burst_type)) {
         sync_->time.increment();
+        if (metrics_) {
+            metrics_->set_time(sync_->time);
+        }
     }
 
     if (burst_type == BurstType::SynchronizationBurst) {
@@ -316,7 +319,7 @@ auto LowerMac::process(const std::vector<uint8_t>& frame, BurstType burst_type) 
 
         // Update the mismatching received number of bursts metrics
         if (current_sync && sync_ && metrics_) {
-            metrics_->increment(/*current_timestamp=*/current_sync->time, /*expected_timestamp=*/sync_->time);
+            metrics_->set_time(/*current_timestamp=*/current_sync->time, /*expected_timestamp=*/sync_->time);
         }
         sync_ = current_sync;
     }

--- a/src/l2/slot.cpp
+++ b/src/l2/slot.cpp
@@ -29,7 +29,7 @@ Slots::Slots(BurstType burst_type, SlotsType slot_type, Slot&& slot)
     /// the information from the access assignment from the corresponding downlink timeslot to make the right
     /// decision here.
     if (burst_type_ == BurstType::NormalUplinkBurst) {
-        get_first_slot().select_logical_channel(LogicalChannel::kSignalingChannelFull);
+        get_first_slot().select_logical_channel(LogicalChannel::kSignallingChannelFull);
     }
 
     if (!get_first_slot().is_concreate()) {

--- a/src/l2/slot.cpp
+++ b/src/l2/slot.cpp
@@ -17,6 +17,117 @@ auto operator<<(std::ostream& stream, const Slot& slot) -> std::ostream& {
     return stream;
 }
 
+Slots::Slots(BurstType burst_type, SlotsType slot_type, Slot&& slot)
+    : burst_type_(burst_type)
+    , slot_type_(slot_type)
+    , slots_({std::move(slot)}) {
+    if (slot_type_ == SlotsType::kTwoSubslots) {
+        throw std::runtime_error("Two subslots need to to have two subslots");
+    }
+
+    /// If we processes the normal uplink burst assume that the slot is signalling and not traffic. We would need
+    /// the information from the access assignment from the corresponding downlink timeslot to make the right
+    /// decision here.
+    if (burst_type_ == BurstType::NormalUplinkBurst) {
+        get_first_slot().select_logical_channel(LogicalChannel::kSignalingChannelFull);
+    }
+
+    if (!get_first_slot().is_concreate()) {
+        throw std::runtime_error("The first or only slot is not concreate.");
+    }
+};
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+Slots::Slots(BurstType burst_type, SlotsType slot_type, Slot&& first_slot, Slot&& second_slot)
+    : burst_type_(burst_type)
+    , slot_type_(slot_type)
+    , slots_({std::move(first_slot), std::move(second_slot)}) {
+    if (slot_type_ != SlotsType::kTwoSubslots) {
+        throw std::runtime_error("Only two subslots is allowed to have two subslots");
+    }
+
+    if (!get_first_slot().is_concreate()) {
+        throw std::runtime_error("The first subslot is not concreate.");
+    }
+
+    const auto& first_slot_data = get_first_slot().get_logical_channel_data_and_crc().data;
+    if (get_first_slot().get_logical_channel_data_and_crc().channel == LogicalChannel::kStealingChannel) {
+        // The first subslot is stolen, now we need to decide if the second is also stolen or traffic
+        auto second_half_slot_stolen = false;
+
+        if (burst_type_ == BurstType::NormalUplinkBurstSplit) {
+            auto pdu_type = first_slot_data.look<2>(0);
+            // read the stolen flag from the MAC-DATA
+            // 21.4.2.3 MAC-DATA
+            if (pdu_type == 0b00) {
+                auto address_type = first_slot_data.look<2>(4);
+                auto length_indication_or_capacity_request_offset = 6 + (address_type == 0b01 ? 10 : 24);
+                auto length_indication_or_capacity_request =
+                    first_slot_data.look<1>(length_indication_or_capacity_request_offset);
+                if (length_indication_or_capacity_request == 0b0) {
+                    auto length_indication = first_slot_data.look<6>(length_indication_or_capacity_request_offset + 1);
+                    if (length_indication == 0b111110 || length_indication == 0b111111) {
+                        second_half_slot_stolen = true;
+                    }
+                }
+            }
+
+            // read the stolen flag from the MAC-U-SIGNAL PDU
+            // 21.4.5 TMD-SAP: MAC PDU structure for U-plane signalling
+            if (pdu_type == 0b11) {
+                if (first_slot_data.look<1>(2)) {
+                    second_half_slot_stolen = true;
+                };
+            }
+        }
+
+        if (burst_type_ == BurstType::NormalDownlinkBurstSplit) {
+            auto pdu_type = first_slot_data.look<2>(0);
+            // read the sloten flag from the MAC-RESOURCE PDU
+            // 21.4.3.1 MAC-RESOURCE
+            if (pdu_type == 0b00) {
+                auto length_indication = first_slot_data.look<6>(7);
+                if (length_indication == 0b111110 || length_indication == 0b111111) {
+                    second_half_slot_stolen = true;
+                }
+            }
+
+            // read the stolen flag from the MAC-U-SIGNAL PDU
+            // 21.4.5 TMD-SAP: MAC PDU structure for U-plane signalling
+            if (pdu_type == 0b11) {
+                if (first_slot_data.look<1>(2)) {
+                    second_half_slot_stolen = true;
+                };
+            }
+        }
+
+        get_second_slot().select_logical_channel(second_half_slot_stolen ? LogicalChannel::kStealingChannel
+                                                                         : LogicalChannel::kTrafficChannel);
+    }
+
+    if (!get_second_slot().is_concreate()) {
+        throw std::runtime_error("The second slot is not concreate.");
+    }
+};
+
+auto Slots::has_crc_error() -> bool {
+    auto error = false;
+
+    const auto& first_slot = slots_.front().get_logical_channel_data_and_crc();
+    if (first_slot.channel != LogicalChannel::kTrafficChannel) {
+        error |= !first_slot.crc_ok;
+    }
+
+    if (has_second_slot()) {
+        const auto& second_slot = slots_.at(1).get_logical_channel_data_and_crc();
+        if (second_slot.channel != LogicalChannel::kTrafficChannel) {
+            error |= !first_slot.crc_ok;
+        }
+    }
+
+    return error;
+};
+
 auto operator<<(std::ostream& stream, const Slots& slots) -> std::ostream& {
     stream << "Slots:" << std::endl;
     stream << "  [BurstType] " << to_string(slots.burst_type_) << std::endl;

--- a/src/l2/upper_mac_packet_builder.cpp
+++ b/src/l2/upper_mac_packet_builder.cpp
@@ -9,7 +9,6 @@
 #include "l2/upper_mac_packet_builder.hpp"
 #include "burst_type.hpp"
 #include "l2/logical_channel.hpp"
-#include "l2/slot.hpp"
 #include "l2/upper_mac_packet.hpp"
 #include "utils/address.hpp"
 #include "utils/bit_vector.hpp"
@@ -40,33 +39,15 @@ auto operator<<(std::ostream& stream, const UpperMacPackets& packets) -> std::os
     return stream;
 }
 
-auto UpperMacPacketBuilder::parse_slots(Slots& slots) -> UpperMacPackets {
-    UpperMacPackets packets;
-
-    {
-        const auto& first_slot = slots.get_first_slot().get_logical_channel_data_and_crc();
-        packets.merge(parse_slot(slots.get_burst_type(), first_slot));
-    }
-
-    if (slots.has_second_slot()) {
-        const auto& second_slot = slots.get_second_slot().get_logical_channel_data_and_crc();
-        packets.merge(parse_slot(slots.get_burst_type(), second_slot));
-    }
-
-    return packets;
-}
-
-auto UpperMacPacketBuilder::parse_slot(const BurstType burst_type,
-                                       const LogicalChannelDataAndCrc& logical_channel_data_and_crc)
-    -> UpperMacPackets {
-    const auto& channel = logical_channel_data_and_crc.channel;
-    auto data = BitVector(logical_channel_data_and_crc.data);
+auto UpperMacPacketBuilder::parse_slot(const ConcreateSlot& slot) -> UpperMacPackets {
+    const auto& channel = slot.logical_channel_data_and_crc.channel;
+    auto data = BitVector(slot.logical_channel_data_and_crc.data);
     if (channel == LogicalChannel::kTrafficChannel) {
         return UpperMacPackets{.u_plane_traffic_packet_ = parse_u_plane_traffic(channel, std::move(data))};
     }
 
     // filter out signalling packets with a wrong crc
-    if (!logical_channel_data_and_crc.crc_ok) {
+    if (!slot.logical_channel_data_and_crc.crc_ok) {
         return UpperMacPackets{};
     }
 
@@ -81,20 +62,20 @@ auto UpperMacPacketBuilder::parse_slot(const BurstType burst_type,
             return UpperMacPackets{.u_plane_signalling_packet_ = {parse_u_plane_signalling(channel, std::move(data))}};
         }
         return UpperMacPackets{.c_plane_signalling_packets_ =
-                                   parse_c_plane_signalling(burst_type, channel, std::move(data))};
+                                   parse_c_plane_signalling(slot.burst_type, channel, std::move(data))};
     }
 
     if (pdu_type == 0b10) {
         // Broadcast
         // TMB-SAP
-        if (is_downlink_burst(burst_type)) {
+        if (is_downlink_burst(slot.burst_type)) {
             return UpperMacPackets{.broadcast_packet_ = parse_broadcast(channel, std::move(data))};
         }
         throw std::runtime_error("Broadcast may only be sent on downlink.");
     }
 
     return UpperMacPackets{.c_plane_signalling_packets_ =
-                               parse_c_plane_signalling(burst_type, channel, std::move(data))};
+                               parse_c_plane_signalling(slot.burst_type, channel, std::move(data))};
 }
 
 auto UpperMacPacketBuilder::parse_broadcast(LogicalChannel channel, BitVector&& data) -> UpperMacBroadcastPacket {

--- a/src/l2/upper_mac_packet_builder.cpp
+++ b/src/l2/upper_mac_packet_builder.cpp
@@ -164,6 +164,7 @@ auto UpperMacPacketBuilder::extract_tm_sdu(BitVector& data, std::size_t preproce
     return data.take_vector(payload_length);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 auto UpperMacPacketBuilder::parse_c_plane_signalling_packet(BurstType burst_type, LogicalChannel channel,
                                                             BitVector& data) -> UpperMacCPlaneSignallingPacket {
     auto preprocessing_bit_count = data.bits_left();

--- a/src/l2/upper_mac_packet_builder.cpp
+++ b/src/l2/upper_mac_packet_builder.cpp
@@ -169,9 +169,9 @@ auto UpperMacPacketBuilder::parse_c_plane_signalling_packet(BurstType burst_type
                                                             BitVector& data) -> UpperMacCPlaneSignallingPacket {
     auto preprocessing_bit_count = data.bits_left();
 
-    if (channel == LogicalChannel::kSignalingChannelHalfUplink) {
+    if (channel == LogicalChannel::kSignallingChannelHalfUplink) {
         if (is_downlink_burst(burst_type)) {
-            throw std::runtime_error("SignalingChannelHalfUplink may only be set on uplink.");
+            throw std::runtime_error("SignallingChannelHalfUplink may only be set on uplink.");
         }
 
         auto pdu_type = data.take<1>();
@@ -330,7 +330,7 @@ auto UpperMacPacketBuilder::parse_c_plane_signalling_packet(BurstType burst_type
                 throw std::runtime_error("Supplementary MAC PDU subtype 0b1 is reserved.");
             }
 
-            if (channel != LogicalChannel::kSignalingChannelFull) {
+            if (channel != LogicalChannel::kSignallingChannelFull) {
                 throw std::runtime_error("MAC-U-BLCK may only be sent on SCH/F.");
             }
 
@@ -484,7 +484,7 @@ auto UpperMacPacketBuilder::parse_c_plane_signalling_packet(BurstType burst_type
                 throw std::runtime_error("Supplementary MAC PDU subtype 0b1 is reserved.");
             }
 
-            if (channel != LogicalChannel::kSignalingChannelFull) {
+            if (channel != LogicalChannel::kSignallingChannelFull) {
                 throw std::runtime_error("MAC-D-BLCK may only be sent on SCH/F.");
             }
 
@@ -526,9 +526,9 @@ auto UpperMacPacketBuilder::parse_c_plane_signalling(const BurstType burst_type,
     if (is_downlink_burst(burst_type)) {
         min_bit_count = 16;
     } else {
-        if (channel == LogicalChannel::kSignalingChannelHalfUplink) {
+        if (channel == LogicalChannel::kSignallingChannelHalfUplink) {
             min_bit_count = 36;
-        } else if (channel == LogicalChannel::kSignalingChannelFull || channel == LogicalChannel::kStealingChannel) {
+        } else if (channel == LogicalChannel::kSignallingChannelFull || channel == LogicalChannel::kStealingChannel) {
             min_bit_count = 37;
         }
     }

--- a/src/prometheus.cpp
+++ b/src/prometheus.cpp
@@ -31,3 +31,11 @@ auto PrometheusExporter::burst_lower_mac_mismatch_count() noexcept -> prometheus
         .Labels({{"name", prometheus_name_}})
         .Register(*registry_);
 }
+
+auto PrometheusExporter::lower_mac_time_gauge() noexcept -> prometheus::Family<prometheus::Gauge>& {
+    return prometheus::BuildGauge()
+        .Name("lower_mac_time_gauge")
+        .Help("The gauge for the network time")
+        .Labels({{"name", prometheus_name_}})
+        .Register(*registry_);
+}

--- a/src/prometheus.cpp
+++ b/src/prometheus.cpp
@@ -39,3 +39,19 @@ auto PrometheusExporter::lower_mac_time_gauge() noexcept -> prometheus::Family<p
         .Labels({{"name", prometheus_name_}})
         .Register(*registry_);
 }
+
+auto PrometheusExporter::upper_mac_total_slot_count() noexcept -> prometheus::Family<prometheus::Counter>& {
+    return prometheus::BuildCounter()
+        .Name("upper_mac_total_slot_count")
+        .Help("Incrementing counter of the number of received slots in the upper MAC")
+        .Labels({{"name", prometheus_name_}})
+        .Register(*registry_);
+}
+
+auto PrometheusExporter::upper_mac_slot_error_count() noexcept -> prometheus::Family<prometheus::Counter>& {
+    return prometheus::BuildCounter()
+        .Name("upper_mac_slot_error_count")
+        .Help("Incrementing counter of the number of received slots in the upper MAC with errors.")
+        .Labels({{"name", prometheus_name_}})
+        .Register(*registry_);
+}


### PR DESCRIPTION
between lower and upper mac:
- [ ] count and LogicalChannel of the received Slot
- [ ]  count and LogicalChannel of the Slot with crc errors
- [ ]  count and LogicalChannel of the Slot with decoding errors



upper mac:
- [ ]  count and type of decoded packet (UpperMacCPlaneSignallingPacket, UpperMacUPlaneSignallingPacket, UpperMacUPlaneTrafficPacket, UpperMacBroadcastPacket)
- [ ] upper mac/c-plane signalling:

 count and MacPacketType of the decoded c-plane signalling packets (separation of MAC-RESOURCE and MAC-DATA for fragmented)
- [ ]  number of reconstructed fragments
- [ ]  number of unsuccessful fragments

logical link control:
- [ ]  count and LLC PDU type metrics